### PR TITLE
Refactor simplifying the logic on trend

### DIFF
--- a/main/backtest/backtest_manager_intraday.py
+++ b/main/backtest/backtest_manager_intraday.py
@@ -115,7 +115,7 @@ class BacktestManagerIntraday(Strategy):
         # Ideally, this "trendAnalysis.is_upTrend" should actually be inside of the strategy class.
         # Notice that we want to be able to run this class even when trying to "discovery an intrady strategy". 
         # So, the concept of trend would not defined yet.
-        if self.trendAnalysis.is_upTrend():
+        if self.trendAnalysis.is_onTrend():
             if self.strategyBuy.shouldBuy(): self.buy(sl=stop_loss, tp=take_profit)
         else:
             #keeps updating trigger status even if not on trend
@@ -135,7 +135,7 @@ class BacktestManagerIntraday(Strategy):
         # In case there's a opened position, just skip the logic. 
         if self.position: return
 
-        if self.trendAnalysis.is_downTrend():
+        if self.trendAnalysis.is_onTrend():
             if self.strategySell.shouldSell(): self.sell(sl=stop_loss, tp=take_profit)       
 
     def try_close_short_position(self):

--- a/main/common/strategyLong.py
+++ b/main/common/strategyLong.py
@@ -16,7 +16,7 @@ class StrategyLong:
         self.trend_analysis = None
 
     def ShouldOpen(self):
-        if self.trend_analysis.is_upTrend():
+        if self.trend_analysis.is_onTrend():
             return self.strategy_buy.shouldBuy()
         return False
 

--- a/main/common/trendanalysis.py
+++ b/main/common/trendanalysis.py
@@ -2,11 +2,5 @@ class TrendAnalysis():
     def __init__(self, trend):
         self.trend = trend
 
-    def is_upTrend(self):
-        if self.trend.__class__.__name__[0:self.trend.__class__.__name__.find("_")] == "UpTrend":
-            return self.trend.ontrend()
-
-    def is_downTrend(self):
-        if self.trend.__class__.__name__[0:self.trend.__class__.__name__.find("_")] == "DownTrend":
-            return self.trend.ontrend()
-
+    def is_onTrend(self):
+        return self.trend.ontrend()

--- a/main/prod/strategy_manager.py
+++ b/main/prod/strategy_manager.py
@@ -92,7 +92,7 @@ class StrategyManager():
 
     # check if can open position
     def try_open_position(self):
-        if self.trendAnalysis.is_upTrend():
+        if self.trendAnalysis.is_onTrend():
             if self.strategyBuy.shouldBuy():
                 strategy = strategy_dao.get_strategy_by_name(self.strategy.__class__.__name__)
                 return self.negotiate.open_position(Side_Type.LONG, self.order_value, strategy.id)


### PR DESCRIPTION
Instead of having `is_upTrend` and `is_downTrend`, I can we have a generic `is_onTrend`. This would allow us to easily define Strategies that operate SHORT even when is a upTrend. Is up to the Strategy to define which Trend would use. That's the key!